### PR TITLE
Try js imports for css

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,11 @@
-import "../styles.css";
+// Works in dev, but breaks in prod.
+// (Try yarn build && yarn serve, and look at header nav menu on mobile.)
+import "@reach/dialog/styles.css";
+import "tailwindcss/tailwind.css";
+
+// This works
+// import "../styles.css";
+
 import "../fonts/Inter/inter.css";
 import { animated, useTransition, useChain } from "react-spring";
 import { DialogOverlay, DialogContent } from "@reach/dialog";


### PR DESCRIPTION
In prod, the order of the css imports is changing such that Tailwind does not come after `@reach/dialog/styles.css`, which leads to the mobile menu styling to be broken since Tailwind classes no longer take precedence.

You can see it in the preview on small screens: https://samselikoff-com-git-try-js-imports-for-css.samselikoff.vercel.app/

Looks like this:

![image](https://user-images.githubusercontent.com/2922250/91478851-94e05d80-e86e-11ea-90e0-902cf645f738.png)
